### PR TITLE
Allow passing in various reduction flags

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,42 +27,42 @@ module.exports = function (opts) {
 		var args = ['-strip', 'all', '-clobber', '-force', '-fix'];
 		var optimizationLevel = opts.optimizationLevel || 2;
 		// −nb: Do not apply bit depth reduction
-		var reduceBitDepth = opts.reduceBitDepth || true;
+		var keepBitDepth = opts.keepBitDepth || false;
 		// −nc: Do not apply color type reduction
-		var reduceColorType = opts.reduceColorType || true;
+		var keepColorType = opts.keepColorType || false;
 		// −np: Do not apply palette reduction
-		var reducePalette = opts.reducePalette || true;
+		var keepPalette = opts.keepPalette || false;
 		// −nz: Do not recode IDAT datastreams
-		var reduceIDAT = opts.reduceIDAT || true;
+		var keepIDAT = opts.keepIDAT || false;
 
 		if (typeof optimizationLevel === 'number') {
 			args.push('-o', optimizationLevel);
 		}
 
 		// reduce bit depth
-		if (typeof reduceBitDepth === 'boolean') {
-			if (!reduceBitDepth) {
+		if (typeof keepBitDepth === 'boolean') {
+			if (keepBitDepth === true) {
 				args.push('-nb');
 			}
 		}
 
 		// reduce color type
-		if (typeof reduceColorType === 'boolean') {
-			if (!reduceColorType) {
+		if (typeof keepColorType === 'boolean') {
+			if (keepColorType === true) {
 				args.push('-nc');
 			}
 		}
 
 		// reduce palette
-		if (typeof reducePalette === 'boolean') {
-			if (!reducePalette) {
+		if (typeof keepPalette === 'boolean') {
+			if (keepPalette === true) {
 				args.push('-np');
 			}
 		}
 
 		// reduce IDAT
-		if (typeof reduceIDAT === 'boolean') {
-			if (!reduceIDAT) {
+		if (typeof keepIDAT === 'boolean') {
+			if (keepIDAT === true) {
 				args.push('-nz');
 			}
 		}

--- a/index.js
+++ b/index.js
@@ -26,9 +26,45 @@ module.exports = function (opts) {
 		var execBuffer = new ExecBuffer();
 		var args = ['-strip', 'all', '-clobber', '-force', '-fix'];
 		var optimizationLevel = opts.optimizationLevel || 2;
+		// −nb: Do not apply bit depth reduction
+		var reduceBitDepth = opts.reduceBitDepth || true;
+		// −nc: Do not apply color type reduction
+		var reduceColorType = opts.reduceColorType || true;
+		// −np: Do not apply palette reduction
+		var reducePalette = opts.reducePalette || true;
+		// −nz: Do not recode IDAT datastreams
+		var reduceIDAT = opts.reduceIDAT || true;
 
 		if (typeof optimizationLevel === 'number') {
 			args.push('-o', optimizationLevel);
+		}
+
+		// reduce bit depth
+		if (typeof reduceBitDepth === 'boolean') {
+			if (!reduceBitDepth) {
+				args.push('-nb');
+			}
+		}
+
+		// reduce color type
+		if (typeof reduceColorType === 'boolean') {
+			if (!reduceColorType) {
+				args.push('-nc');
+			}
+		}
+
+		// reduce palette
+		if (typeof reducePalette === 'boolean') {
+			if (!reducePalette) {
+				args.push('-np');
+			}
+		}
+
+		// reduce IDAT
+		if (typeof reduceIDAT === 'boolean') {
+			if (!reduceIDAT) {
+				args.push('-nz');
+			}
 		}
 
 		execBuffer

--- a/test/test.js
+++ b/test/test.js
@@ -16,3 +16,60 @@ test('optimize a PNG', async function (t) {
 
 	stream.end(file);
 });
+
+// test: −nb: Do not apply bit depth reduction
+test('optimize a PNG, but keep bit depth', async function (t) {
+	const stream = imageminOptipng({
+		keepBitDepth: true
+	})();
+	const file = await vinylFile.read(path.join(__dirname, 'fixtures/test.png'));
+
+	stream.on('data', (data) => {
+		t.assert(isPng(data.contents));
+	});
+
+	stream.end(file);
+});
+
+// test: −nc: Do not apply color type reduction
+test('optimize a PNG, but keep color type', async function (t) {
+	const stream = imageminOptipng({
+		keepColorType: true
+	})();
+	const file = await vinylFile.read(path.join(__dirname, 'fixtures/test.png'));
+
+	stream.on('data', (data) => {
+		t.assert(isPng(data.contents));
+	});
+
+	stream.end(file);
+});
+
+// test: −np: Do not apply palette reduction
+test('optimize a PNG, but do not reduce palette', async function (t) {
+	const stream = imageminOptipng({
+		keepPalette: true
+	})();
+	const file = await vinylFile.read(path.join(__dirname, 'fixtures/test.png'));
+
+	stream.on('data', (data) => {
+		t.assert(isPng(data.contents));
+	});
+
+	stream.end(file);
+});
+
+// test: −nz: Do not recode IDAT datastreams
+test('optimize a PNG, but do not recode IDAT datastreams', async function (t) {
+	const stream = imageminOptipng({
+		keepIDAT: true
+	})();
+	const file = await vinylFile.read(path.join(__dirname, 'fixtures/test.png'));
+
+	stream.on('data', (data) => {
+		t.assert(isPng(data.contents));
+	});
+
+	stream.end(file);
+});
+


### PR DESCRIPTION
Hello! I'd like to allow for a couple of options to be passed in, namely:
- `−nb`: Do not apply bit depth reduction
- `−nc`: Do not apply color type reduction
- `−np`: Do not apply palette reduction
- `−nz`: Do not recode IDAT datastreams

...as this is a feature I've been needing recently, and pngcrush doesn't seem to be quite as speedy as optipng. So, this PR introduces this feature in accordance with [the docs](http://optipng.sourceforge.net/optipng-0.7.5.man.pdf). The flags are opt-in to keep the default compression behaviour.

Example usage:
```
optimizationLevel: 3,
keepBitDepth: true,
keepColorType: false,
keepPalette: false,
keepIDAT: false
```