### PR TITLE
Add reduction options

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,9 +6,9 @@ const optipng = require('optipng-bin');
 module.exports = opts => buf => {
 	opts = Object.assign({
 		optimizationLevel: 3,
-		enableBitDepthReduction: true,
-		enableColorTypeReduction: true,
-		enablePaletteReduction: true
+		bitDepthReduction: true,
+		colorTypeReduction: true,
+		paletteReduction: true
 	}, opts);
 
 	if (!Buffer.isBuffer(buf)) {
@@ -29,15 +29,15 @@ module.exports = opts => buf => {
 		execBuffer.input
 	];
 
-	if (!opts.enableBitDepthReduction) {
+	if (!opts.bitDepthReduction) {
 		args.push('−nb');
 	}
 
-	if (!opts.enableColorTypeReduction) {
+	if (!opts.colorTypeReduction) {
 		args.push('−nc');
 	}
 
-	if (!opts.enablePaletteReduction) {
+	if (!opts.paletteReduction) {
 		args.push('−np');
 	}
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,12 @@ const isPng = require('is-png');
 const optipng = require('optipng-bin');
 
 module.exports = opts => buf => {
-	opts = Object.assign({optimizationLevel: 3}, opts);
+	opts = Object.assign({
+		optimizationLevel: 3,
+		enableBitDepthReduction: true,
+		enableColorTypeReduction: true,
+		enablePaletteReduction: true
+	}, opts);
 
 	if (!Buffer.isBuffer(buf)) {
 		return Promise.reject(new TypeError('Expected a buffer'));
@@ -23,6 +28,18 @@ module.exports = opts => buf => {
 		'-out', execBuffer.output,
 		execBuffer.input
 	];
+
+	if (!opts.enableBitDepthReduction) {
+		args.push('−nb');
+	}
+
+	if (!opts.enableColorTypeReduction) {
+		args.push('−nc');
+	}
+
+	if (!opts.enablePaletteReduction) {
+		args.push('−np');
+	}
 
 	return execBuffer({
 		input: buf,

--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,27 @@ Level and trials:
 6. 120 trials
 7. 240 trials
 
+##### enableBitDepthReduction
+
+Type: `boolean`<br>
+Default: `true`
+
+Apply bit depth reduction.
+
+##### enableColorTypeReduction
+
+Type: `boolean`<br>
+Default: `true`
+
+Apply color type reduction.
+
+##### enablePaletteReduction
+
+Type: `boolean`<br>
+Default: `true`
+
+Apply palette reduction.
+
 #### buffer
 
 Type: `buffer`

--- a/readme.md
+++ b/readme.md
@@ -49,21 +49,21 @@ Level and trials:
 6. 120 trials
 7. 240 trials
 
-##### enableBitDepthReduction
+##### bitDepthReduction
 
 Type: `boolean`<br>
 Default: `true`
 
 Apply bit depth reduction.
 
-##### enableColorTypeReduction
+##### colorTypeReduction
 
 Type: `boolean`<br>
 Default: `true`
 
 Apply color type reduction.
 
-##### enablePaletteReduction
+##### paletteReduction
 
 Type: `boolean`<br>
 Default: `true`


### PR DESCRIPTION
Adds optional arguments:

* `−nb` Do not apply bit depth reduction.
* `−nc` Do not apply color type reduction.
* `−np` Do not apply palette reduction.

Closes #10 