### PR TITLE
Bump the optipng-bin version to ^3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "exec-buffer": "^3.0.0",
     "is-png": "^1.0.0",
-    "optipng-bin": "^3.0.0"
+    "optipng-bin": "^3.1.0"
   },
   "devDependencies": {
     "ava": "*",

--- a/test.js
+++ b/test.js
@@ -30,13 +30,13 @@ test('throw on corrupt image', t => {
 });
 
 test('bitDepthReduction', async t => {
-	t.notThrows(m({bitDepthReduction: true})(buf));
+	await t.notThrows(m({bitDepthReduction: true})(buf));
 });
 
 test('colorTypeReduction', async t => {
-	t.notThrows(m({colorTypeReduction: true})(buf));
+	await t.notThrows(m({colorTypeReduction: true})(buf));
 });
 
 test('paletteReduction', async t => {
-	t.notThrows(m({paletteReduction: true})(buf));
+	await t.notThrows(m({paletteReduction: true})(buf));
 });


### PR DESCRIPTION
Trying to resolve the same issue as https://github.com/imagemin/imagemin/issues/160

It is not limited to windows. Problem occurs in a Ubuntu Xenial (16.04) machine too with Node v6.9.2