### PR TITLE
Add option to keep metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea
 node_modules
 yarn.lock

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ module.exports = options => async buffer => {
 		paletteReduction: true,
 		interlaced: false,
 		errorRecovery: true,
+		strip: true,
 		...options
 	};
 
@@ -23,14 +24,17 @@ module.exports = options => async buffer => {
 	}
 
 	const arguments_ = [
-		'-strip',
-		'all',
 		'-clobber',
 		'-o',
 		options.optimizationLevel,
 		'-out',
 		execBuffer.output
 	];
+
+	if (options.strip) {
+		arguments_.unshift('all');
+		arguments_.unshift('-strip');
+	}
 
 	if (options.errorRecovery) {
 		arguments_.push('-fix');

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,13 @@ Default: `true`
 
 A reasonable amount of effort will be spent to try to recover as much data as possible of a broken image, but the success cannot generally be guaranteed.
 
+##### strip
+
+Type: `boolean`<br>
+Default: `false`
+
+Strip metadata objects from a PNG file.
+
 #### buffer
 
 Type: `Buffer`


### PR DESCRIPTION
This PR adds the option to preserve the image metadata. More explanation https://manpages.debian.org/stretch/optipng/optipng.1.en.html