### PR TITLE
Use native ESM and update dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,64 +1,26 @@
 name: test
-
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
-
+  - push
+  - pull_request
 jobs:
-  linux:
-    runs-on: ubuntu-latest
-
+  test:
+    name: Node.js ${{ matrix.node-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        node-version: [10.x, 12.x, 14.x]
-
+        node-version:
+          - 12
+          - 14
+          - 16
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm install
-    - run: npm test
-      env:
-        CI: true
-
-  macos:
-    runs-on: macos-latest
-
-    strategy:
-      matrix:
-        node-version: [10.x, 12.x, 14.x]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm install
-    - run: npm test
-      env:
-        CI: true
-
-  windows:
-    runs-on: windows-latest
-
-    strategy:
-      matrix:
-        node-version: [10.x, 12.x, 14.x]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm install
-    - run: npm test
-      env:
-        CI: true
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm test

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
-'use strict';
-const execBuffer = require('exec-buffer');
-const isPng = require('is-png');
-const optipng = require('optipng-bin');
+import {Buffer} from 'node:buffer';
+import execBuffer from 'exec-buffer';
+import isPng from 'is-png';
+import optipng from 'optipng-bin';
 
-module.exports = options => async buffer => {
+const main = options => async buffer => {
 	options = {
 		optimizationLevel: 3,
 		bitDepthReduction: true,
@@ -11,7 +11,7 @@ module.exports = options => async buffer => {
 		paletteReduction: true,
 		interlaced: false,
 		errorRecovery: true,
-		...options
+		...options,
 	};
 
 	if (!Buffer.isBuffer(buffer)) {
@@ -29,7 +29,7 @@ module.exports = options => async buffer => {
 		'-o',
 		options.optimizationLevel,
 		'-out',
-		execBuffer.output
+		execBuffer.output,
 	];
 
 	if (options.errorRecovery) {
@@ -57,6 +57,8 @@ module.exports = options => async buffer => {
 	return execBuffer({
 		input: buffer,
 		bin: optipng,
-		args: arguments_
+		args: arguments_,
 	});
 };
+
+export default main;

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
 	"description": "Imagemin plugin for OptiPNG",
 	"license": "MIT",
 	"repository": "imagemin/imagemin-optipng",
+	"type": "module",
 	"engines": {
-		"node": ">=10"
+		"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 	},
 	"scripts": {
 		"test": "xo && ava"
@@ -24,11 +25,11 @@
 	],
 	"dependencies": {
 		"exec-buffer": "^3.0.0",
-		"is-png": "^2.0.0",
-		"optipng-bin": "^7.0.0"
+		"is-png": "^3.0.1",
+		"optipng-bin": "^8.1.0"
 	},
 	"devDependencies": {
-		"ava": "^3.8.0",
-		"xo": "^0.30.0"
+		"ava": "^4.0.1",
+		"xo": "^0.47.0"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# imagemin-optipng
+# imagemin-optipng ![GitHub Actions Status](https://github.com/imagemin/imagemin-optipng/workflows/test/badge.svg?branch=main)
 
 > Imagemin plugin for OptiPNG
 
@@ -11,8 +11,8 @@ $ npm install imagemin-optipng
 ## Usage
 
 ```js
-const imagemin = require('imagemin');
-const imageminOptipng = require('imagemin-optipng');
+import imagemin from 'imagemin';
+import imageminOptipng from 'imagemin-optipng';
 
 (async () => {
 	await imagemin(['images/*.png'], {

--- a/test.js
+++ b/test.js
@@ -1,11 +1,10 @@
-const fs = require('fs');
-const path = require('path');
-const isPng = require('is-png');
-const test = require('ava');
-const optipng = require('.');
+import fs from 'node:fs';
+import isPng from 'is-png';
+import test from 'ava';
+import optipng from './index.js';
 
-const fixture = fs.readFileSync(path.join(__dirname, 'fixture.png'));
-const fixtureBroken = fs.readFileSync(path.join(__dirname, 'fixture_broken.png'));
+const fixture = fs.readFileSync(new URL('fixture.png', import.meta.url));
+const fixtureBroken = fs.readFileSync(new URL('fixture_broken.png', import.meta.url));
 
 test('optimize a PNG', async t => {
 	const data = await optipng()(fixture);
@@ -46,7 +45,7 @@ test('errorRecovery is set to false', async t => {
 test('interlaced is set to true', async t => {
 	const [data1, data2] = await Promise.all([
 		optipng({interlaced: true})(fixture),
-		optipng()(fixture)
+		optipng()(fixture),
 	]);
 
 	t.true(isPng(data1));
@@ -57,7 +56,7 @@ test('interlaced is set to undefined and null', async t => {
 	const [data1, data2, data3] = await Promise.all([
 		optipng({interlaced: undefined})(fixture),
 		optipng({interlaced: null})(fixture),
-		optipng({interlaced: true})(fixture)
+		optipng({interlaced: true})(fixture),
 	]);
 
 	t.true(isPng(data1) && isPng(data2));


### PR DESCRIPTION
I basically did the same changes as this PR https://github.com/imagemin/imagemin-gifsicle/pull/53 to migrate CJS to ESM 😬 

It's the last package among https://github.com/sindresorhus/gulp-imagemin/blob/main/package.json#L57-L60 that is still using CJS

```
	"optionalDependencies": {
		"imagemin-gifsicle": "^7.0.0",
		"imagemin-mozjpeg": "^9.0.0",
		"imagemin-optipng": "^8.0.0",
		"imagemin-svgo": "^9.0.0"
	},
```